### PR TITLE
feat: Allow use of multiple headers for loadbalancing policy

### DIFF
--- a/caskethttp/proxy/policy_test.go
+++ b/caskethttp/proxy/policy_test.go
@@ -327,18 +327,18 @@ func TestHeaderPolicy(t *testing.T) {
 		NilHost            bool
 		HostIndex          int
 	}{
-		{"empty config", &Header{""}, "", "", true, 0},
-		{"empty config+header+value", &Header{""}, "Affinity", "somevalue", true, 0},
-		{"empty config+header", &Header{""}, "Affinity", "", true, 0},
+		{"empty config", &Header{nil}, "", "", true, 0},
+		{"empty config+header+value", &Header{nil}, "Affinity", "somevalue", true, 0},
+		{"empty config+header", &Header{nil}, "Affinity", "", true, 0},
 
-		{"no header(fallback to roundrobin)", &Header{"Affinity"}, "", "", false, 1},
-		{"no header(fallback to roundrobin)", &Header{"Affinity"}, "", "", false, 2},
-		{"no header(fallback to roundrobin)", &Header{"Affinity"}, "", "", false, 0},
+		{"no header(fallback to roundrobin)", &Header{[]string{"Affinity"}}, "", "", false, 1},
+		{"no header(fallback to roundrobin)", &Header{[]string{"Affinity"}}, "", "", false, 2},
+		{"no header(fallback to roundrobin)", &Header{[]string{"Affinity"}}, "", "", false, 0},
 
-		{"hash route to host", &Header{"Affinity"}, "Affinity", "somevalue", false, 1},
-		{"hash route to host", &Header{"Affinity"}, "Affinity", "somevalue2", false, 0},
-		{"hash route to host", &Header{"Affinity"}, "Affinity", "somevalue3", false, 2},
-		{"hash route with empty value", &Header{"Affinity"}, "Affinity", "", false, 1},
+		{"hash route to host", &Header{[]string{"Affinity"}}, "Affinity", "somevalue", false, 1},
+		{"hash route to host", &Header{[]string{"Affinity"}}, "Affinity", "somevalue2", false, 0},
+		{"hash route to host", &Header{[]string{"Affinity"}}, "Affinity", "somevalue3", false, 2},
+		{"hash route with empty value", &Header{[]string{"Affinity"}}, "Affinity", "", false, 1},
 	}
 
 	for idx, test := range tests {

--- a/caskethttp/proxy/upstream.go
+++ b/caskethttp/proxy/upstream.go
@@ -36,12 +36,12 @@ import (
 
 	"crypto/tls"
 
-	"github.com/tmpim/casket/caskethttp/httpserver"
 	"github.com/tmpim/casket/casketfile"
+	"github.com/tmpim/casket/caskethttp/httpserver"
 )
 
 var (
-	supportedPolicies = make(map[string]func(string) Policy)
+	supportedPolicies = make(map[string]func([]string) Policy)
 )
 
 type staticUpstream struct {
@@ -346,11 +346,11 @@ func parseBlock(c *casketfile.Dispenser, u *staticUpstream, hasSrv bool) error {
 		if !ok {
 			return c.ArgErr()
 		}
-		arg := ""
-		if c.NextArg() {
-			arg = c.Val()
+		var args []string
+		for c.NextArg() {
+			args = append(args, c.Val())
 		}
-		u.Policy = policyCreateFunc(arg)
+		u.Policy = policyCreateFunc(args)
 	case "fallback_delay":
 		if !c.NextArg() {
 			return c.ArgErr()
@@ -780,7 +780,7 @@ func (u *staticUpstream) Stop() error {
 }
 
 // RegisterPolicy adds a custom policy to the proxy.
-func RegisterPolicy(name string, policy func(string) Policy) {
+func RegisterPolicy(name string, policy func([]string) Policy) {
 	supportedPolicies[name] = policy
 }
 

--- a/caskethttp/proxy/upstream_test.go
+++ b/caskethttp/proxy/upstream_test.go
@@ -127,7 +127,7 @@ func TestSelect(t *testing.T) {
 func TestRegisterPolicy(t *testing.T) {
 	name := "custom"
 	customPolicy := &customPolicy{}
-	RegisterPolicy(name, func(string) Policy { return customPolicy })
+	RegisterPolicy(name, func([]string) Policy { return customPolicy })
 	if _, ok := supportedPolicies[name]; !ok {
 		t.Error("Expected supportedPolicies to have a custom policy.")
 	}


### PR DESCRIPTION
Example Syntax:
```
	proxy / localhost:3001 localhost:3002 {
		policy header X-My-Header X-My-Other-Header
	}
```