### PR TITLE
feat: add tryfiles

### DIFF
--- a/caskethttp/caskethttp.go
+++ b/caskethttp/caskethttp.go
@@ -44,6 +44,7 @@ import (
 	_ "github.com/tmpim/casket/caskethttp/status"
 	_ "github.com/tmpim/casket/caskethttp/templates"
 	_ "github.com/tmpim/casket/caskethttp/timeouts"
+	_ "github.com/tmpim/casket/caskethttp/tryfiles"
 	_ "github.com/tmpim/casket/caskethttp/websocket"
 	_ "github.com/tmpim/casket/onevent"
 )

--- a/caskethttp/caskethttp_test.go
+++ b/caskethttp/caskethttp_test.go
@@ -25,7 +25,7 @@ import (
 // ensure that the standard plugins are in fact plugged in
 // and registered properly; this is a quick/naive way to do it.
 func TestStandardPlugins(t *testing.T) {
-	numStandardPlugins := 32 // importing caskethttp plugs in this many plugins
+	numStandardPlugins := 33 // importing caskethttp plugs in this many plugins
 	s := casket.DescribePlugins()
 	if got, want := strings.Count(s, "\n"), numStandardPlugins+4; got != want {
 		t.Errorf("Expected all standard plugins to be plugged in, got:\n%s", s)

--- a/caskethttp/httpserver/plugin.go
+++ b/caskethttp/httpserver/plugin.go
@@ -641,6 +641,7 @@ var directives = []string{
 	"locale", // github.com/simia-tech/casket-locale
 	"log",
 	"cache", // github.com/nicolasazrak/casket-cache
+	"tryfiles",
 	"rewrite",
 	"ext",
 	"minify", // github.com/hacdias/casket-minify

--- a/caskethttp/rewrite/to.go
+++ b/caskethttp/rewrite/to.go
@@ -26,7 +26,7 @@ import (
 
 // To attempts rewrite. It attempts to rewrite to first valid path
 // or the last path if none of the paths are valid.
-func To(fs http.FileSystem, r *http.Request, to string, replacer httpserver.Replacer) Result {
+func To(fs http.FileSystem, r *http.Request, to string, replacer httpserver.Replacer, without ...string) Result {
 	tos := strings.Fields(to)
 
 	// try each rewrite paths
@@ -35,7 +35,12 @@ func To(fs http.FileSystem, r *http.Request, to string, replacer httpserver.Repl
 	for _, v := range tos {
 		t = replacer.Replace(v)
 		tparts := strings.SplitN(t, "?", 2)
-		t = path.Clean(tparts[0])
+
+		if len(without) > 0 {
+			t = path.Clean(strings.TrimPrefix(tparts[0], without[0]))
+		} else {
+			t = path.Clean(tparts[0])
+		}
 
 		if len(tparts) > 1 {
 			query = tparts[1]

--- a/caskethttp/staticfiles/fileserver.go
+++ b/caskethttp/staticfiles/fileserver.go
@@ -115,7 +115,7 @@ func (fs FileServer) serveFile(w http.ResponseWriter, r *http.Request) (int, err
 				urlCopy.Path = strings.TrimPrefix(urlCopy.Path, "/")
 			}
 			urlCopy.Path += "/"
-			http.Redirect(w, r, urlCopy.String(), http.StatusMovedPermanently)
+			http.Redirect(w, r, urlCopy.String(), http.StatusTemporaryRedirect)
 			return 0, nil
 		}
 	} else {
@@ -126,23 +126,12 @@ func (fs FileServer) serveFile(w http.ResponseWriter, r *http.Request) (int, err
 			redir = true
 		}
 
-		// if an index file was explicitly requested, strip file name from the request
-		// ("/foo/index.html" -> "/foo/")
-		var requestPage = path.Base(urlCopy.Path)
-		for _, indexPage := range fs.IndexPages {
-			if requestPage == indexPage {
-				urlCopy.Path = urlCopy.Path[:len(urlCopy.Path)-len(indexPage)]
-				redir = true
-				break
-			}
-		}
-
 		if redir {
 			for strings.HasPrefix(urlCopy.Path, "//") {
 				// prevent path-based open redirects
 				urlCopy.Path = strings.TrimPrefix(urlCopy.Path, "/")
 			}
-			http.Redirect(w, r, urlCopy.String(), http.StatusMovedPermanently)
+			http.Redirect(w, r, urlCopy.String(), http.StatusTemporaryRedirect)
 			return 0, nil
 		}
 	}

--- a/caskethttp/staticfiles/fileserver_test.go
+++ b/caskethttp/staticfiles/fileserver_test.go
@@ -42,7 +42,7 @@ func TestServeHTTP(t *testing.T) {
 		IndexPages: DefaultIndexPages,
 	}
 
-	movedPermanently := "Moved Permanently"
+	temporaryRedirect := "Temporary Redirect"
 
 	tests := []struct {
 		url                   string
@@ -85,9 +85,9 @@ func TestServeHTTP(t *testing.T) {
 		// Test 4 - access folder with index file without trailing slash
 		{
 			url:                 "https://foo/dirwithindex",
-			expectedStatus:      http.StatusMovedPermanently,
+			expectedStatus:      http.StatusTemporaryRedirect,
 			expectedLocation:    "https://foo/dirwithindex/",
-			expectedBodyContent: movedPermanently,
+			expectedBodyContent: temporaryRedirect,
 		},
 		// Test 5 - access folder without index file
 		{
@@ -97,16 +97,16 @@ func TestServeHTTP(t *testing.T) {
 		// Test 6 - access folder without trailing slash
 		{
 			url:                 "https://foo/dir",
-			expectedStatus:      http.StatusMovedPermanently,
+			expectedStatus:      http.StatusTemporaryRedirect,
 			expectedLocation:    "https://foo/dir/",
-			expectedBodyContent: movedPermanently,
+			expectedBodyContent: temporaryRedirect,
 		},
 		// Test 7 - access file with trailing slash
 		{
 			url:                 "https://foo/file1.html/",
-			expectedStatus:      http.StatusMovedPermanently,
+			expectedStatus:      http.StatusTemporaryRedirect,
 			expectedLocation:    "https://foo/file1.html",
-			expectedBodyContent: movedPermanently,
+			expectedBodyContent: temporaryRedirect,
 		},
 		// Test 8 - access not existing path
 		{
@@ -120,22 +120,24 @@ func TestServeHTTP(t *testing.T) {
 		},
 		// Test 10 - access an index file directly
 		{
-			url:              "https://foo/dirwithindex/index.html",
-			expectedStatus:   http.StatusMovedPermanently,
-			expectedLocation: "https://foo/dirwithindex/",
+			url:                   "https://foo/dirwithindex/index.html",
+			expectedStatus:        http.StatusOK,
+			expectedBodyContent:   testFiles[webrootDirwithindexIndexHTML],
+			expectedEtag:          `"2n9cw"`,
+			expectedContentLength: strconv.Itoa(len(testFiles[webrootDirwithindexIndexHTML])),
 		},
 		// Test 11 - access an index file with a trailing slash
 		{
 			url:              "https://foo/dirwithindex/index.html/",
-			expectedStatus:   http.StatusMovedPermanently,
-			expectedLocation: "https://foo/dirwithindex/",
+			expectedStatus:   http.StatusTemporaryRedirect,
+			expectedLocation: "https://foo/dirwithindex/index.html",
 		},
 		// Test 12 - send a request with query params
 		{
 			url:                 "https://foo/dir?param1=val",
-			expectedStatus:      http.StatusMovedPermanently,
+			expectedStatus:      http.StatusTemporaryRedirect,
 			expectedLocation:    "https://foo/dir/?param1=val",
-			expectedBodyContent: movedPermanently,
+			expectedBodyContent: temporaryRedirect,
 		},
 		// Test 13 - attempt to bypass hidden file
 		{
@@ -215,25 +217,25 @@ func TestServeHTTP(t *testing.T) {
 		{
 			url:                 "https://foo/bar/dirwithindex",
 			stripPathPrefix:     "/bar/",
-			expectedStatus:      http.StatusMovedPermanently,
+			expectedStatus:      http.StatusTemporaryRedirect,
 			expectedLocation:    "https://foo/bar/dirwithindex/",
-			expectedBodyContent: movedPermanently,
+			expectedBodyContent: temporaryRedirect,
 		},
 		// Test 25 - access folder with index file without trailing slash, with stripped path and query params
 		{
 			url:                 "https://foo/bar/dirwithindex?param1=val",
 			stripPathPrefix:     "/bar/",
-			expectedStatus:      http.StatusMovedPermanently,
+			expectedStatus:      http.StatusTemporaryRedirect,
 			expectedLocation:    "https://foo/bar/dirwithindex/?param1=val",
-			expectedBodyContent: movedPermanently,
+			expectedBodyContent: temporaryRedirect,
 		},
 		// Test 26 - site defined with path ("bar"), which has that prefix stripped
 		{
 			url:                 "https://foo/bar/file1.html/",
 			stripPathPrefix:     "/bar/",
-			expectedStatus:      http.StatusMovedPermanently,
+			expectedStatus:      http.StatusTemporaryRedirect,
 			expectedLocation:    "https://foo/bar/file1.html",
-			expectedBodyContent: movedPermanently,
+			expectedBodyContent: temporaryRedirect,
 		},
 		{
 			// Test 27 - Check etag
@@ -246,23 +248,24 @@ func TestServeHTTP(t *testing.T) {
 		{
 			// Test 28 - Prevent path-based open redirects (directory)
 			url:                 "https://foo//example.com%2f..",
-			expectedStatus:      http.StatusMovedPermanently,
+			expectedStatus:      http.StatusTemporaryRedirect,
 			expectedLocation:    "https://foo/example.com/../",
-			expectedBodyContent: movedPermanently,
+			expectedBodyContent: temporaryRedirect,
 		},
 		{
 			// Test 29 - Prevent path-based open redirects (file)
-			url:                 "https://foo//example.com%2f../dirwithindex/index.html",
-			expectedStatus:      http.StatusMovedPermanently,
-			expectedLocation:    "https://foo/example.com/../dirwithindex/",
-			expectedBodyContent: movedPermanently,
+			url:                   "https://foo//example.com%2f../dirwithindex/index.html",
+			expectedStatus:        http.StatusOK,
+			expectedBodyContent:   testFiles[webrootDirwithindexIndexHTML],
+			expectedEtag:          `"2n9cw"`,
+			expectedContentLength: strconv.Itoa(len(testFiles[webrootDirwithindexIndexHTML])),
 		},
 		{
 			// Test 29 - Prevent path-based open redirects (extra leading slashes)
 			url:                 "https://foo///example.com%2f..",
-			expectedStatus:      http.StatusMovedPermanently,
+			expectedStatus:      http.StatusTemporaryRedirect,
 			expectedLocation:    "https://foo/example.com/../",
-			expectedBodyContent: movedPermanently,
+			expectedBodyContent: temporaryRedirect,
 		},
 		// Test 30 - try to get pre- file.
 		{

--- a/caskethttp/tryfiles/tryfiles.go
+++ b/caskethttp/tryfiles/tryfiles.go
@@ -1,0 +1,116 @@
+package browse
+
+import (
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/tmpim/casket"
+	"github.com/tmpim/casket/caskethttp/httpserver"
+	"github.com/tmpim/casket/caskethttp/rewrite"
+	"github.com/tmpim/casket/caskethttp/staticfiles"
+)
+
+func init() {
+	casket.RegisterPlugin("tryfiles", casket.Plugin{
+		ServerType: "http",
+		Action:     setup,
+	})
+}
+
+type Config struct {
+	To      string
+	Except  []string
+	Without string
+}
+
+type TryFiles struct {
+	Next    httpserver.Handler
+	FileSys http.FileSystem
+	Config  *Config
+}
+
+func (t *TryFiles) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
+	for _, p := range t.Config.Except {
+		if strings.HasPrefix(r.URL.Path, p) {
+			return t.Next.ServeHTTP(w, r)
+		}
+	}
+
+	if t.Config.Without != "" {
+		rewrite.To(t.FileSys, r, t.Config.To, httpserver.NewReplacer(r, nil, ""), t.Config.Without)
+	} else {
+		rewrite.To(t.FileSys, r, t.Config.To, httpserver.NewReplacer(r, nil, ""))
+	}
+
+	return t.Next.ServeHTTP(w, r)
+}
+
+// setup configures a new Browse middleware instance.
+func setup(c *casket.Controller) error {
+	config, err := tryFilesParse(c)
+	if err != nil {
+		return err
+	}
+
+	cfg := httpserver.GetConfig(c)
+
+	b := &TryFiles{
+		Config:  config,
+		FileSys: http.Dir(cfg.Root),
+	}
+
+	httpserver.GetConfig(c).AddMiddleware(func(next httpserver.Handler) httpserver.Handler {
+		b.Next = next
+		return b
+	})
+
+	return nil
+}
+
+func tryFilesParse(c *casket.Controller) (*Config, error) {
+	cfg := httpserver.GetConfig(c)
+
+	config := &Config{
+		To:      "{path} " + strings.Join(staticfiles.DefaultIndexPages, " "),
+		Except:  []string{"/.well-known"},
+		Without: cfg.Addr.Path,
+	}
+
+	if config.Without == "/" {
+		config.Without = ""
+	}
+
+	if config.Without != "" {
+		config.Except = append(config.Except, path.Join(config.Without, "/.well-known"))
+	}
+
+	for c.Next() {
+		tryFileArgs := c.RemainingArgs()
+		if len(tryFileArgs) == 0 {
+			continue
+		}
+
+		config.To = strings.Join(tryFileArgs, " ")
+
+		for c.NextBlock() {
+			val := c.Val()
+			args := c.RemainingArgs()
+
+			switch val {
+			case "except":
+				config.Except = args
+			case "without":
+				if len(args) != 1 {
+					return nil, c.Err("`without` directive must have exactly one argument")
+				}
+
+				config.Without = args[0]
+			default:
+				return nil, c.ArgErr()
+			}
+		}
+	}
+
+	return config, nil
+}

--- a/caskethttp/tryfiles/tryfiles.go
+++ b/caskethttp/tryfiles/tryfiles.go
@@ -32,7 +32,7 @@ type TryFiles struct {
 
 func (t *TryFiles) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	for _, p := range t.Config.Except {
-		if strings.HasPrefix(r.URL.Path+"/", p+"/") {
+		if httpserver.Path(r.URL.Path).Matches(p) {
 			return t.Next.ServeHTTP(w, r)
 		}
 	}

--- a/caskethttp/tryfiles/tryfiles.go
+++ b/caskethttp/tryfiles/tryfiles.go
@@ -32,7 +32,7 @@ type TryFiles struct {
 
 func (t *TryFiles) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	for _, p := range t.Config.Except {
-		if strings.HasPrefix(r.URL.Path, p) {
+		if strings.HasPrefix(r.URL.Path+"/", p+"/") {
 			return t.Next.ServeHTTP(w, r)
 		}
 	}

--- a/caskethttp/tryfiles/tryfiles.go
+++ b/caskethttp/tryfiles/tryfiles.go
@@ -46,7 +46,6 @@ func (t *TryFiles) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error
 	return t.Next.ServeHTTP(w, r)
 }
 
-// setup configures a new Browse middleware instance.
 func setup(c *casket.Controller) error {
 	config, err := tryFilesParse(c)
 	if err != nil {


### PR DESCRIPTION
This PR adds a `tryfiles` directive to make it easier to serve compiled static content (React, Vue, etc.) for single page/progressive web apps or whatever you call them.

The default configuration (i.e. you only specify `tryfiles` and nothing else) looks like this:
```bash
# files to try in order
tryfiles {path} index.html index.htm index.txt default.html default.htm default.txt {
    # specify paths to exclude from this rule
    except /.well-known {cfg.addr.path}/.well-known
    # specify path prefixes to strip before trying to find them on the filesystem.
    without {cfg.addr.path}
}
```

where `{cfg.addr.path}` refers to the configured host's path if it is hosted on a subpath. For example:
```bash
chuie.io/example {
    # server config
}

# {cfg.addr.path} == "/example"
```

I also fixed some annoying bullshit like how the built in handler would redirect index.html _permanently_??? which imo is kinda ass. Now it doesn't attempt to redirect index.html at all, and it will only use temporary redirects.

@Lustyn @emmachase lmk what you think and if this covers your/all needs

Resolves #10 