### PR TITLE
Fix Unit File

### DIFF
--- a/dist/init/linux-systemd/casket.service
+++ b/dist/init/linux-systemd/casket.service
@@ -33,7 +33,7 @@ TimeoutStopSec=5s
 ; Limit the number of file descriptors; see `man systemd.exec` for more limit settings.
 LimitNOFILE=1048576
 ; Unmodified casket is not expected to use more than that.
-LimitNPROC=512
+TasksMax=512
 
 ; Use private /tmp and /var/tmp, which are discarded after casket stops.
 PrivateTmp=true


### PR DESCRIPTION
LimitNPROC -> TasksMax

LimitNPROC is a per-user limit, meaning the moment www-data went over 512 processes, and another process was added by the unit, it would crash.

Maybe worth considering reducing the number from 512 as well?