### PR TITLE
fix: more responsive browse template

### DIFF
--- a/caskethttp/browse/default_template.html
+++ b/caskethttp/browse/default_template.html
@@ -85,10 +85,6 @@ main {
 	padding-bottom: 10px;
 }
 
-.meta-item {
-	margin-right: 1em;
-}
-
 .dropdown {
     position: relative;
     font-weight: bold;
@@ -145,6 +141,7 @@ main {
 #filter {
 	padding: 4px;
 	border: 1px solid #cccccc;
+	box-sizing: border-box;
 }
 
 table {
@@ -265,7 +262,20 @@ footer {
 	}
 
 	#filter {
-		max-width: 100px;
+		width: 100%;
+	}
+
+	.meta-item.filter-item {
+		flex: 1;
+	}
+
+	#summary {
+		flex-wrap: wrap;
+		gap: 0.5em 1em;
+	}
+
+	#summary > .filler {
+		flex-basis: 100%;
 	}
 }
 </style>
@@ -328,7 +338,7 @@ footer {
 					{{- if ne 0 .ItemsLimitedTo}}
 					<span class="meta-item">(of which only <b>{{.ItemsLimitedTo}}</b> are displayed)</span>
 					{{- end}}
-					<span class="meta-item"><input type="text" placeholder="filter" id="filter" onkeyup='filter()'></span>
+					<span class="meta-item filter-item"><input type="text" placeholder="filter" id="filter" onkeyup='filter()'></span>
                     <span class="filler"></span>
                     {{- if .ArchiveTypes }}
                     <div class="dropdown" onclick="">

--- a/caskethttp/browse/default_template.html
+++ b/caskethttp/browse/default_template.html
@@ -31,6 +31,10 @@ header,
 	padding-right: 5%;
 }
 
+#summary {	
+	gap: 0.5em 1em;
+}
+
 .filler {
     flex: 1;
 }
@@ -271,7 +275,6 @@ footer {
 
 	#summary {
 		flex-wrap: wrap;
-		gap: 0.5em 1em;
 	}
 
 	#summary > .filler {


### PR DESCRIPTION
Makes the filter box and download box flow a little better on mobile, mainly with servearchive.

### With servearchive
Before:
![chrome_lkHvB9dFPx](https://github.com/tmpim/casket/assets/858456/b85f3e5c-9af6-4ed7-84d2-180cef2dd57b)

**After**:
![chrome_HSnlwWATqK](https://github.com/tmpim/casket/assets/858456/53fd7e56-8ea9-467e-8391-ef627d62a0c2)

### Without servearchive
Before:
![chrome_AVPFRahzzo](https://github.com/tmpim/casket/assets/858456/58ef4106-bca6-4bd9-a11e-54b611ae1e9b)

**After**:
![chrome_9tC95vf8th](https://github.com/tmpim/casket/assets/858456/19e26f4a-30e5-442d-b7c5-d71925517805)
