### PR TITLE
feat: HTTP -> HTTPS redirects on all site configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ access.log
 
 /*.conf
 Casketfile
+Casketfile.*
 !casketfile/
 casket/go.mod
 casket/go.sum

--- a/caskethttp/httpserver/https.go
+++ b/caskethttp/httpserver/https.go
@@ -29,7 +29,7 @@ func activateHTTPS(cctx casket.Context) error {
 	operatorPresent := !casket.Started()
 
 	if !casket.Quiet && operatorPresent {
-		fmt.Print("Activating privacy features... ")
+		fmt.Println("Activating privacy features... ")
 	}
 
 	ctx := cctx.(*httpContext)
@@ -147,7 +147,8 @@ func makePlaintextRedirects(allConfigs []*SiteConfig) []*SiteConfig {
 	httpPort := strconv.Itoa(certmagic.HTTPPort)
 	httpsPort := strconv.Itoa(certmagic.HTTPSPort)
 	for i, cfg := range allConfigs {
-		if cfg.TLS.Managed &&
+		if cfg.TLS.Enabled &&
+			!cfg.TLS.NoRedirect &&
 			!hostHasOtherPort(allConfigs, i, httpPort) &&
 			(cfg.Addr.Port == httpsPort || !hostHasOtherPort(allConfigs, i, httpsPort)) {
 			allConfigs = append(allConfigs, redirPlaintextHost(cfg))
@@ -191,6 +192,11 @@ func redirPlaintextHost(cfg *SiteConfig) *SiteConfig {
 		// advanced, and the user should configure HTTP->HTTPS
 		// redirects themselves.)
 		redirPort = ""
+	}
+
+	operatorPresent := !casket.Started()
+	if !casket.Quiet && operatorPresent {
+		fmt.Println("[INFO] Creating automatic HTTP->HTTPS redirect for", cfg.Addr.Host)
 	}
 
 	redirMiddleware := func(next Handler) Handler {

--- a/caskethttp/httpserver/https_test.go
+++ b/caskethttp/httpserver/https_test.go
@@ -23,8 +23,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/tmpim/certmagic"
 	"github.com/tmpim/casket/caskettls"
+	"github.com/tmpim/certmagic"
 )
 
 func TestRedirPlaintextHost(t *testing.T) {
@@ -153,18 +153,18 @@ func TestHostHasOtherPort(t *testing.T) {
 func TestMakePlaintextRedirects(t *testing.T) {
 	configs := []*SiteConfig{
 		// Happy path = standard redirect from 80 to 443
-		{Addr: Address{Host: "example.com"}, TLS: &caskettls.Config{Managed: true}},
+		{Addr: Address{Host: "example.com"}, TLS: &caskettls.Config{Managed: true, Enabled: true}},
 
 		// Host on port 80 already defined; don't change it (no redirect)
 		{Addr: Address{Host: "sub1.example.com", Port: "80", Scheme: "http"}, TLS: new(caskettls.Config)},
-		{Addr: Address{Host: "sub1.example.com"}, TLS: &caskettls.Config{Managed: true}},
+		{Addr: Address{Host: "sub1.example.com"}, TLS: &caskettls.Config{Managed: true, Enabled: true}},
 
 		// Redirect from port 80 to port 5000 in this case
-		{Addr: Address{Host: "sub2.example.com", Port: "5000"}, TLS: &caskettls.Config{Managed: true}},
+		{Addr: Address{Host: "sub2.example.com", Port: "5000"}, TLS: &caskettls.Config{Managed: true, Enabled: true}},
 
 		// Can redirect from 80 to either 443 or 5001, but choose 443
-		{Addr: Address{Host: "sub3.example.com", Port: "443"}, TLS: &caskettls.Config{Managed: true}},
-		{Addr: Address{Host: "sub3.example.com", Port: "5001", Scheme: "https"}, TLS: &caskettls.Config{Managed: true}},
+		{Addr: Address{Host: "sub3.example.com", Port: "443"}, TLS: &caskettls.Config{Managed: true, Enabled: true}},
+		{Addr: Address{Host: "sub3.example.com", Port: "5001", Scheme: "https"}, TLS: &caskettls.Config{Managed: true, Enabled: true}},
 	}
 
 	result := makePlaintextRedirects(configs)

--- a/caskettls/config.go
+++ b/caskettls/config.go
@@ -84,6 +84,10 @@ type Config struct {
 	// Manager is how certificates are managed
 	Manager *certmagic.Config
 
+	// NoRedirect will disable the automatic HTTP->HTTPS redirect, regardless
+	// of whether the site is managed or not.
+	NoRedirect bool
+
 	// SelfSigned means that this hostname is
 	// served with a self-signed certificate
 	// that we generated in memory for convenience

--- a/caskettls/setup.go
+++ b/caskettls/setup.go
@@ -278,6 +278,8 @@ func setupTLS(c *casket.Controller) error {
 				}
 				parts[0] = "*"
 				config.Hostname = strings.Join(parts, ".")
+			case "no_redirect":
+				config.NoRedirect = true
 			default:
 				return c.Errf("Unknown subdirective '%s'", c.Val())
 			}


### PR DESCRIPTION
This PR changes the default behavior for setting up HTTP to HTTPS redirects. Previously, the redirects would only be set up if Casket was managing the TLS (it qualifies for automatic HTTPS). 

## Background

The conventional advice for servers using their own certificates or `tls self_signed` was to set up a redirect rule manually, like so:

```
redir 301 {
  if {>X-Forwarded-Proto} is http
  /  https://{host}{uri}
}
```

This is fine for one-off deployments, but when doing this for many domains, it becomes more appropriate to use a template. So, one might try:

```
(tls-selfsigned) {
  tls self_signed

  redir 301 {
    if {>X-Forwarded-Proto} is http
    /  https://{host}{uri}
  }
}

example.com {
  import tls-selfsigned
}
```

However, if the site that imports the template already has a redirect rule for `/`, this configuration will conflict. Thus, the desire to change the default behavior.

## Solution

With this PR, all sites that have TLS enabled in any way will have a redirect created on the HTTP port. **This is potentially a breaking change**; if a configuration already assumes that nothing would be bound on port 80. To disable this behavior, you can now opt-out of the redirect creation per-site (even if the site qualifies for automatic HTTPS like before):

```
https://example.com {
  tls self_signed {
    no_redirect # Disable the automatic HTTP -> HTTPS redirect
  }
}
```